### PR TITLE
es6-shim no longer needed

### DIFF
--- a/source/angular-cli.md
+++ b/source/angular-cli.md
@@ -22,6 +22,8 @@ We need to disable declarations for `es6` features in `src/tsconfig.json` by rep
 }
 ```
 
+> Since v0.8 above changes **no longer apply**.
+
 About `typed-graphql`, we need to make it visible somehow. Put the refference inside `src/typings.d.ts`:
 
 ```ts

--- a/source/initialization.md
+++ b/source/initialization.md
@@ -18,6 +18,8 @@ Those libraries require few additional type declarations:
 npm install @types/{chai,es6-shim,isomorphic-fetch,node} typed-graphql
 ```
 
+> Since v0.8 you don't have to install `@types/es6-shim`. You can **skip [*ES2015* section](#typescript-es2015)**.
+
 <h3 id="typescript-es2015">ES2015</h3>
 
 TypeScript 2.0 comes with a set of predefined type declarations.


### PR DESCRIPTION
@Urigo I added just a note, instead of removing the whole thing. Is it okay? We can remove the whole section in the next big release.