### PR TITLE
No longer need to install @types and to change anything in ts config

### DIFF
--- a/source/angular-cli.md
+++ b/source/angular-cli.md
@@ -6,31 +6,6 @@ title: Angular CLI
 
 To get started with Apollo and Angular install few needed packages. Take a look at [Installation](initialization.html#installation) section.
 
-<h2 id="typescript">TypeScript</h2>
-
-As follows in [TypeScript](initialization.html#typescript) chapter, you need to do few changes in your project.
-
-We need to disable declarations for `es6` features in `src/tsconfig.json` by replacing it for the ones from `es5`:
-
-```ts
-{
-  "compilerOptions": {
-    // ...
-    "lib": ["es5", "dom"]
-    // ...
-  }
-}
-```
-
-> Since v0.8 above changes **no longer apply**.
-
-About `typed-graphql`, we need to make it visible somehow. Put the refference inside `src/typings.d.ts`:
-
-```ts
-/// <reference types="typed-graphql" />
-```
-
-
 <h2 id="initialization">Initialization</h2>
 
 Take a look at [Initialization](initialization.html) section.

--- a/source/cache-updates.md
+++ b/source/cache-updates.md
@@ -55,7 +55,7 @@ class FeedComponent implements OnInit {
   offset: number = 0;
   itemsPerPage: number = 10;
   feedObs: ApolloQueryObservable<any>;
-  
+
   ngOnInit() {
     this.feedObs = this.apollo.watchQuery({
       query: feedQuery,

--- a/source/initialization.md
+++ b/source/initialization.md
@@ -10,37 +10,6 @@ To get started with Apollo and Angular, install the `apollo-client` npm package,
 npm install apollo-client angular2-apollo graphql-tag --save
 ```
 
-<h2 id="typescript">TypeScript</h2>
-
-Those libraries require few additional type declarations:
-
-```bash
-npm install @types/{chai,es6-shim,isomorphic-fetch,node} typed-graphql --save-dev
-```
-
-> Since v0.8 you don't have to install `@types/es6-shim`. You can **skip [*ES2015* section](#typescript-es2015)**.
-
-<h3 id="typescript-es2015">ES2015</h3>
-
-TypeScript 2.0 comes with a set of predefined type declarations.
-If you're using one of them that brings ES2015 (ES6) you should disable it, because `@types/es6-shim` will cause an issue with multiple types definitons.
-
-It's easy, just replace `es6`, `es2015` or similar options from `compilerOptions.lib` for `es5`.
-
-<h3 id="typescript-graphql">GraphQL</h3>
-
-Since `typed-graphql` is not a package under `@types` scope, it's not visible by TypeScript compiler.
-
-There are to ways of changing this.
-
-First approach would be to include `node_modules/typed-graphql/graphql.d.ts` to your project. Take a look at [TypeScript documenation](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html).
-
-Second way would be to add global reference to one of files.
-
-```ts
-/// <reference types="typed-graphql" />
-```
-
 <h2 id="initialization">Initialization</h2>
 
 To get started using Apollo, we need to create an `ApolloClient` and use `ApolloModule`. `ApolloClient` serves as a central store of query result data which caches and distributes the results of our queries. `ApolloModule` wires that client into your application.

--- a/source/mutations.md
+++ b/source/mutations.md
@@ -41,7 +41,7 @@ Using `Angular2Apollo` it easy to call mutation. You can simply use `mutate` met
 ```ts
 import { Component } from '@angular/core';
 import { Angular2Apollo } from 'angular2-apollo';
-import { gql } from 'graphql-tag';
+import gql from 'graphql-tag';
 
 const submitRepository = gql`
   mutation submitRepository {
@@ -70,7 +70,7 @@ Most mutations will require arguments in the form of query variables, and you ma
 ```ts
 import { Component } from '@angular/core';
 import { Angular2Apollo } from 'angular2-apollo';
-import { gql } from 'graphql-tag';
+import gql from 'graphql-tag';
 
 const submitRepository = gql`
   mutation submitRepository($repoFullName: String!) {
@@ -114,7 +114,7 @@ Apollo Client gives you a way to specify the `optimisticResponse` option, that w
 ```ts
 import { Component } from '@angular/core';
 import { Angular2Apollo } from 'angular2-apollo';
-import { gql } from 'graphql-tag';
+import gql from 'graphql-tag';
 
 const submitComment = gql`
   mutation submitComment($repoFullName: String!, $commentContent: String!) {


### PR DESCRIPTION
@Urigo What do you think? We have released at least two minor versions of `angular2-apollo` so if someone already updated to `v0.8.0` it's nothing new for him. They had some time to update all so should we remove it from the docs?