### PR TITLE
Just Apollo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,7 @@ sidebar_categories:
     - mutations
     - receiving-updates
     - cache-updates
+    - multiple-clients
   Recipes:
     - auth
     - pagination

--- a/_config.yml
+++ b/_config.yml
@@ -33,6 +33,7 @@ sidebar_categories:
     - angular-cli
     - ahead-of-time
     - webpack
+    - typescript
 github_repo: apollostack/angular2-docs
 content_root: source
 

--- a/source/ahead-of-time.md
+++ b/source/ahead-of-time.md
@@ -36,4 +36,4 @@ To learn more about Ahead-of-Time compilation, please take a look at [the chapte
 
 <h2 id="example">An Example</h2>
 
-We prepared [an example](https://github.com/apollostack/angular2-apollo/tree/master/examples/hello-world) that shows how to use *Ahead-of-Time* compilation with *Apollo*.
+We prepared [an example](https://github.com/apollostack/apollo-angular/tree/master/examples/hello-world) that shows how to use *Ahead-of-Time* compilation with *Apollo*.

--- a/source/auth.md
+++ b/source/auth.md
@@ -9,7 +9,7 @@ Apollo Client has a pluggable [network interface](/core/network.html) that lets 
 That makes it easy to add a network interface middleware that adds the `authorization` header to every HTTP request:
 
 ```ts
-import ApolloClient, { createNetworkInterface } from 'apollo-client';
+import { ApolloClient, createNetworkInterface } from 'apollo-client';
 
 const networkInterface = createNetworkInterface('/graphql');
 

--- a/source/cache-updates.md
+++ b/source/cache-updates.md
@@ -120,7 +120,7 @@ const submitCommentMutation = gql`
 `;
 
 class CommentsPageComponent {
-  apollo: Angular2Apollo;
+  apollo: Apollo;
   currentUser: any;
 
   submit({ repoFullName, commentContent }) {

--- a/source/cache-updates.md
+++ b/source/cache-updates.md
@@ -14,7 +14,7 @@ Apollo's store is [constructed](http://dev.apollodata.com/core/how-it-works.html
 By default, Apollo cannot determine the IDs to use for object except through the position that they take in queries. However, if you specify a function to generate an ID from each object, and supply it as the `dataIdFromObject` in the [`ApolloClient` constructor](initialization.html#creating-client), you can create an unique ID for each "real" object.
 
 ```ts
-import ApolloClient from 'apollo-client';
+import { ApolloClient } from 'apollo-client';
 
 // If your database has unique IDs across all types of objects, you can use
 // a very simple function!

--- a/source/fragments.md
+++ b/source/fragments.md
@@ -63,7 +63,7 @@ const SUBMIT_COMMENT_MUTATION = gql`
   }
 `;
 
-this.angular2Apollo.mutate({
+this.apollo.mutate({
   mutation: SUBMIT_COMMENT_MUTATION,
   fragments: fragments.comment.fragments()
 });
@@ -81,7 +81,7 @@ export const COMMENT_QUERY = gql`
   }
 `;
 
-this.angular2Apollo.watchQuery({
+this.apollo.watchQuery({
   mutation: COMMENT_QUERY,
   fragments: fragments.comment.fragments()
 });
@@ -196,7 +196,7 @@ interface FilteredResult {
 
 // inside a Component
 
-this.angular2Apollo.watchQuery(({
+this.apollo.watchQuery(({
   query,
   variables: { id: 7 }
 })).subscribe(({data}) => {

--- a/source/index.md
+++ b/source/index.md
@@ -21,11 +21,11 @@ The `apollo-client` npm module is a JavaScript client for GraphQL. The goal of t
 2. **Simple to get started with**, you can just read one guide and get going.
 3. **Inspectable and understandable**, so that you can have great developer tools to understand exactly what is happening in your app.
 4. **Built for interactive apps**, so your users can make changes and see them reflected in the UI straight away.
-5. **Community driven**, many of the components of Apollo (including the `angular2-apollo` integration) were driven by our community and serve real-world use cases from the outset, and all components are planned and developed in the open.
+5. **Community driven**, many of the components of Apollo (including the `apollo-angular` integration) were driven by our community and serve real-world use cases from the outset, and all components are planned and developed in the open.
 
 The Apollo client does more than simply run your queries against your GraphQL server. It analyzes your queries and their results to construct a client-side cache of your data, which is updated as further queries, mutations are run and data is pushed to you from the server. This means that your UI can remain fully up-to-date with the state on the server with the minimum number of queries required.
 
-The best way to use `apollo-client` in your Angular app is with `angular2-apollo`, a Angular-specific API that's designed to take full advantage of Apollo. The integration provides a natural API for queries and mutations, and will keep your rendered component tree up to date with the data in the cache seamlessly.
+The best way to use `apollo-client` in your Angular app is with `apollo-angular`, a Angular-specific API that's designed to take full advantage of Apollo. The integration provides a natural API for queries and mutations, and will keep your rendered component tree up to date with the data in the cache seamlessly.
 
 <h2 id="what-it-works-with">What it works with</h2>
 

--- a/source/initialization.md
+++ b/source/initialization.md
@@ -52,7 +52,7 @@ To get started using Apollo, we need to create an `ApolloClient` and use `Apollo
 To get started, create an [`ApolloClient`](/core/apollo-client-api.html#constructor) instance and point it at your GraphQL server:
 
 ```ts
-import ApolloClient from 'apollo-client';
+import { ApolloClient } from 'apollo-client';
 
 // by default, this client will send queries to `/graphql` (relative to the URL of your app)
 const client = new ApolloClient();
@@ -61,7 +61,7 @@ const client = new ApolloClient();
 The client takes a variety of [options](/core/apollo-client-api.html#constructor), but in particular, if you want to change the URL of the GraphQL server, you can pass in a custom [`NetworkInterface`](/core/apollo-client-api.html#NetworkInterface):
 
 ```ts
-import ApolloClient, { createNetworkInterface } from 'apollo-client';
+import { ApolloClient, createNetworkInterface } from 'apollo-client';
 
 // by default, this client will send queries to `/graphql` (relative to the URL of your app)
 const client = new ApolloClient({
@@ -79,10 +79,10 @@ The other options control the behavior of the client, and we'll see examples of 
 
 <h3 id="providing-apollomodule">Providing ApolloModule</h3>
 
-To connect your client instance to your app, use the `ApolloModule.withClient`.
+To connect your client instance to your app, use the `ApolloModule.forRoot`.
 
 ```ts
-import ApolloClient from 'apollo-client';
+import { ApolloClient } from 'apollo-client';
 import { ApolloModule } from 'apollo-angular';
 
 import { NgModule } from '@angular/core';
@@ -101,7 +101,7 @@ export function provideClient(): ApolloClient {
 @NgModule({
   imports: [
     BrowserModule,
-    ApolloModule.withClient(provideClient)
+    ApolloModule.forRoot(provideClient)
   ],
   declarations: [ AppComponent ],
   bootstrap: [ AppComponent ]

--- a/source/initialization.md
+++ b/source/initialization.md
@@ -4,10 +4,10 @@ order: 2
 ---
 <h2 id="installation">Installation</h2>
 
-To get started with Apollo and Angular, install the `apollo-client` npm package, the `angular2-apollo` integration package, and the `graphql-tag` library for constructing query documents:
+To get started with Apollo and Angular, install the `apollo-client` npm package, the `apollo-angular` integration package, and the `graphql-tag` library for constructing query documents:
 
 ```bash
-npm install apollo-client angular2-apollo graphql-tag --save
+npm install apollo-client apollo-angular graphql-tag --save
 ```
 
 If you are in an environment that does not have a global [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch) implementation, make sure to install a polyfill like [`whatwg-fetch`](https://www.npmjs.com/package/whatwg-fetch).
@@ -83,7 +83,7 @@ To connect your client instance to your app, use the `ApolloModule.withClient`.
 
 ```ts
 import ApolloClient from 'apollo-client';
-import { ApolloModule } from 'angular2-apollo';
+import { ApolloModule } from 'apollo-angular';
 
 import { NgModule } from '@angular/core';
 import { BrowserModule  } from '@angular/platform-browser';

--- a/source/initialization.md
+++ b/source/initialization.md
@@ -111,5 +111,7 @@ class AppModule {}
 platformBrowserDynamic().bootstrapModule(AppModule);
 ```
 
+> There is still `ApolloModule.withClient` available but we recommend you to use `ApolloModule.forRoot` instead.
+
 <!--  Add content here once it exists -->
 <!-- ## Troubleshooting -->

--- a/source/multiple-clients.md
+++ b/source/multiple-clients.md
@@ -1,0 +1,50 @@
+---
+title: Multiple clients
+order: 14
+---
+
+With `apollo-angular` it's possible to use multiple instances of ApolloClient in your application.
+
+<h2 id="providing-clients">Providing clients</h2>
+
+It's simple! Make function to return an object where each key is a name and put instance of ApolloClient as a value.
+
+```ts
+export function provideClients() {
+  return {
+    default: client,
+    extra: extraClient,
+  };
+}
+
+ApolloModule.forRoot(provideClients);
+```
+
+If you want to define a default client, simply use `default` as a name.
+
+
+<h2 id="using-apollo">Using Apollo</h2>
+
+Since we have our clients defined, now's time to see how to use them.
+
+```ts
+import { Component, OnInit } from '@angular/core';
+import { Apollo } from 'apollo-angular';
+
+@Component({...})
+export class AppComponent implements OnInit {
+  feed: any;
+
+  constructor(
+    private apollo: Apollo
+  ) {}
+
+  ngOnInit() {
+    // use default
+    this.feed = this.apollo.watchQuery({...});
+
+    // use extra client
+    this.feed = this.apollo.use('extra').watchQuery({...});
+  }
+}
+```

--- a/source/multiple-clients.md
+++ b/source/multiple-clients.md
@@ -7,7 +7,8 @@ With `apollo-angular` it's possible to use multiple instances of ApolloClient in
 
 <h2 id="providing-clients">Providing clients</h2>
 
-It's simple! Make function to return an object where each key is a name and put instance of ApolloClient as a value.
+You're already familiar with the way provide an instance of ApolloClient to the `ApolloModule`.
+Instead of a using a function that returns just one client, change it to return a key-value object, where a key is a unique name of a client and put that client as a value.
 
 ```ts
 export function provideClients() {
@@ -20,12 +21,16 @@ export function provideClients() {
 ApolloModule.forRoot(provideClients);
 ```
 
-If you want to define a default client, simply use `default` as a name.
+As you can see, we defined two clients that are now available to your application.
+
+Important thing to know is if you want to define a default client, simply use `default` as a name.
 
 
 <h2 id="using-apollo">Using Apollo</h2>
 
-Since we have our clients defined, now's time to see how to use them.
+Since we have our clients available in an app, now is the time to see how to use them.
+
+If a client is defined as the default, you can directly use all methods of the `Apollo` service. About named clients, simply use a method called `use(name: string)`.
 
 ```ts
 import { Component, OnInit } from '@angular/core';

--- a/source/multiple-clients.md
+++ b/source/multiple-clients.md
@@ -8,7 +8,7 @@ With `apollo-angular` it's possible to use multiple instances of ApolloClient in
 <h2 id="providing-clients">Providing clients</h2>
 
 You're already familiar with the way provide an instance of ApolloClient to the `ApolloModule`.
-Instead of a using a function that returns just one client, change it to return a key-value object, where a key is a unique name of a client and put that client as a value.
+Instead of using a function that returns just one client, change it to return a key-value object, where a key is a unique name of a client and put that client as a value.
 
 ```ts
 export function provideClients() {
@@ -30,7 +30,9 @@ Important thing to know is if you want to define a default client, simply use `d
 
 Since we have our clients available in an app, now is the time to see how to use them.
 
-If a client is defined as the default, you can directly use all methods of the `Apollo` service. About named clients, simply use a method called `use(name: string)`.
+If a client is defined as the default, you can directly use all methods of the `Apollo` service. 
+
+About named clients, simply use the method called `use(name: string)`.
 
 ```ts
 import { Component, OnInit } from '@angular/core';

--- a/source/mutations.md
+++ b/source/mutations.md
@@ -36,11 +36,11 @@ When we use mutations in Apollo, the result is typically integrated into the cac
 
 <h2 id="basics">Basic Mutations</h2>
 
-Using `Angular2Apollo` it easy to call mutation. You can simply use `mutate` method.      
+Using `Apollo` it easy to call mutation. You can simply use `mutate` method.      
 
 ```ts
 import { Component } from '@angular/core';
-import { Angular2Apollo } from 'angular2-apollo';
+import { Apollo } from 'apollo-angular';
 import { gql } from 'graphql-tag';
 
 const submitRepository = gql`
@@ -53,7 +53,7 @@ const submitRepository = gql`
 
 @Component({ ... })
 class NewEntryComponent {
-  constructor(private apollo: Angular2Apollo) {}
+  constructor(private apollo: Apollo) {}
 
   newRepository() {
     this.apollo.mutate({
@@ -69,7 +69,7 @@ Most mutations will require arguments in the form of query variables, and you ma
 
 ```ts
 import { Component } from '@angular/core';
-import { Angular2Apollo } from 'angular2-apollo';
+import { Apollo } from 'apollo-angular';
 import { gql } from 'graphql-tag';
 
 const submitRepository = gql`
@@ -82,7 +82,7 @@ const submitRepository = gql`
 
 @Component({ ... })
 class NewEntryComponent {
-  constructor(private apollo: Angular2Apollo) {}
+  constructor(private apollo: Apollo) {}
   
   newRepository() {
     this.apollo.mutate({
@@ -113,7 +113,7 @@ Apollo Client gives you a way to specify the `optimisticResponse` option, that w
 
 ```ts
 import { Component } from '@angular/core';
-import { Angular2Apollo } from 'angular2-apollo';
+import { Apollo } from 'apollo-angular';
 import { gql } from 'graphql-tag';
 
 const submitComment = gql`
@@ -133,7 +133,7 @@ const submitComment = gql`
 class CommentPageComponent {
   currentUser: User;
 
-  constructor(private apollo: Angular2Apollo) {}
+  constructor(private apollo: Apollo) {}
 
   submit({ repoFullName, commentContent }) {
     this.apollo.mutate({

--- a/source/optimistic-ui.md
+++ b/source/optimistic-ui.md
@@ -56,7 +56,7 @@ Here is a concrete example from GitHunt, which inserts a comment into an existin
 
 ```ts
 import { Component } from '@angular/core';
-import { Angular2Apollo } from 'angular2-apollo';
+import { Apollo } from 'apollo-angular';
 import gql from 'graphql-tag';
 
 
@@ -77,7 +77,7 @@ const submitCommentMutation = gql`
 class CommentsPageComponent {
   currentUser: any;
 
-  constructor(private apollo: Angular2Apollo) {}
+  constructor(private apollo: Apollo) {}
 
   submit({ repoFullName, commentContent }) {
     this.apollo.mutate({

--- a/source/pagination.md
+++ b/source/pagination.md
@@ -35,7 +35,7 @@ const feedQuery = gql`
 `;
 
 class FeedComponent, OnInit {
-  apollo: Angular2Apollo;
+  apollo: Apollo;
   feedObs: ApolloQueryObservable<any>;
   feed: any[];
   type: string;

--- a/source/prefetching.md
+++ b/source/prefetching.md
@@ -7,12 +7,12 @@ One of the easiest ways to make your application's UI feel a lot snappier with A
 
 In Apollo Client, prefetching is very simple and can be done by running a component's query before rendering.
 
-GitHunt uses `Angular2Apollo` and calls `query` method as soon as the user hovers over a link to the comments page. 
+GitHunt uses `Apollo` and calls `query` method as soon as the user hovers over a link to the comments page. 
 With the data prefetched, the comments page renders immediately, and the user often experiences no delay at all:
 
 ```ts
 import { Component } from '@angular/core';
-import { Angular2Apollo } from 'angular2-apollo';
+import { Apollo } from 'apollo-angular';
 import gql from 'graphql-tag';
 
 @Component({
@@ -28,7 +28,7 @@ class RepoInfoComponent {
   repoName: string;
   entry: any;
 
-  constructor(private apollo: Angular2Apollo) {}
+  constructor(private apollo: Apollo) {}
 
   prefetchComments(repoFullName: string) {
     this.apollo.query({

--- a/source/queries.md
+++ b/source/queries.md
@@ -7,13 +7,13 @@ To fetch data from the server in a GraphQL system, we use GraphQL queries (you c
 
 <h2 id="basics">Basic Queries</h2>
 
-When we are using a basic query we can use the `Angular2Apollo.watchQuery` method in a very simple way. We simply need to parse our query into a GraphQL document using the `graphql-tag` library.
+When we are using a basic query we can use the `Apollo.watchQuery` method in a very simple way. We simply need to parse our query into a GraphQL document using the `graphql-tag` library.
 
 For instance, in GitHunt, we want to display the current user (if logged in) in the `Profile` component:
 
 ```ts
 import { Component, OnInit } from '@angular/core';
-import { Angular2Apollo } from 'angular2-apollo';
+import { Apollo } from 'apollo-angular';
 import gql from 'graphql-tag';
 
 // We use the gql tag to parse our query string into a query document
@@ -31,7 +31,7 @@ class ProfileComponent implements OnInit {
   loading: boolean;
   currentUser: any;
 
-  constructor(private apollo: Angular2Apollo) {}
+  constructor(private apollo: Apollo) {}
 
   ngOnInit() {
     this.apollo.watchQuery({
@@ -48,7 +48,7 @@ The service's `watchQuery` method returns and `Observable` of the query result (
 
 We can expect the `data.currentUser` to change as the logged-in-ness of the client and what it knows about the current user changes over time. That information is stored in Apollo Client's cache, and you can read more about techniques to bring the cache up to date with the server in the [article on the subject](cache-updates.html).
 
-It's also possible to fetch data only once. The `query` method of `Angular2Apollo` service returns an `Observable` that resolves also with [`ApolloQueryResult`][ApolloQueryResult].
+It's also possible to fetch data only once. The `query` method of `Apollo` service returns an `Observable` that resolves also with [`ApolloQueryResult`][ApolloQueryResult].
 
 To be more specific, `watchQuery` method returns an Observable called `ApolloQueryObservable`. It extends the actual `Observable` from `rxjs` package. The only difference is that our observable contains all the methods specific to Apollo, for example `refetch`.
 
@@ -139,7 +139,7 @@ This is why we created `SelectPipe`. The only argument it receives is the name o
 
 ```ts
 import { Component, OnInit } from '@angular/core';
-import { Angular2Apollo, ApolloQueryObservable } from 'angular2-apollo';
+import { Apollo, ApolloQueryObservable } from 'apollo-angular';
 import gql from 'graphql-tag';
 
 const FeedQuery = gql`
@@ -164,7 +164,7 @@ const FeedQuery = gql`
 class FeedComponent implements OnInit {
   data: ApolloQueryObservable<any>;
 
-  constructor(private apollo: Angular2Apollo) {}
+  constructor(private apollo: Apollo) {}
 
   ngOnInit() {
     this.data = this.apollo.watchQuery({ query: FeedQuery });
@@ -187,13 +187,13 @@ Without using `SelectPipe` you would get the whole object instead of only the `d
 
 <h2 id="rxjs">Using with RxJS</h2>
 
-`Angular2Apollo` is compatible with RxJS. It means that an observable called `ApolloQueryObservable`, returned by `watchQuery` method can be used with operators.
+`Apollo` is compatible with RxJS. It means that an observable called `ApolloQueryObservable`, returned by `watchQuery` method can be used with operators.
 
 What's really interesting, because of this you can avoid using `SelectPipe`:
 
 ```ts
 import { Component, OnInit } from '@angular/core';
-import { Angular2Apollo, ApolloQueryObservable } from 'angular2-apollo';
+import { Apollo, ApolloQueryObservable } from 'apollo-angular';
 import gql from 'graphql-tag';
 
 import 'rxjs/add/operator/map';
@@ -220,7 +220,7 @@ const FeedQuery = gql`
 class FeedComponent implements OnInit {
   data: ApolloQueryObservable<any>;
 
-  constructor(private apollo: Angular2Apollo) {}
+  constructor(private apollo: Apollo) {}
 
   ngOnInit() {
     this.data = this.apollo.watchQuery({ query: FeedQuery })

--- a/source/receiving-updates.md
+++ b/source/receiving-updates.md
@@ -14,7 +14,7 @@ For example, continuing with the GitHunt schema, we may have the following compo
 
 ```ts
 import { Component, OnInit } from '@angular/core';
-import { Angular2Apollo } from 'angular2-apollo';
+import { Apollo } from 'apollo-angular';
 import gql from 'grapqhl-tag';
 
 const FeedEntries = gql`
@@ -34,7 +34,7 @@ const FeedEntries = gql`
 class FeedComponent implements OnInit {
   data: any;
   
-  constructor(private apollo: Angular2Apollo) {}
+  constructor(private apollo: Apollo) {}
 
   ngOnInit() {
     this.data = this.apollo.watchQuery({ ... }); 
@@ -60,7 +60,7 @@ Continuing with our refetch example, we can add a polling interval with an addit
 
 ```ts
 class FeedComponent {
-  apollo: Angular2Apollo;
+  apollo: Apollo;
 
   // ...
   ngOnInit() {

--- a/source/typescript.md
+++ b/source/typescript.md
@@ -1,0 +1,43 @@
+---
+title: TypeScript
+---
+
+You can take an advantage of using TypeScript.
+
+<h2 id="generic-types">Generic types</h2>
+
+Every `ApolloQueryResult` has a generic type that you can specify when using methods to manipulate the data.
+
+For example, let's take a look at `watchQuery` method:
+
+```ts
+interface User {
+  username: string;
+  email: string;
+}
+
+interface QueryResponse {
+  currentUser: User;
+}
+
+const UserQuery = gql`
+  query currentUser {
+    currentUser {
+      username
+      email
+    }
+  }
+`;
+
+class AppComponent {
+  user: User;
+
+  ngOnInit() {
+    this.apollo.watchQuery<QueryResponse>({ query: UserQuery })
+      .map(({data}) => data.currentUser);
+  }
+}
+```
+
+The `data` object is a type of `QueryResponse`. 
+Thanks to this, you can prevent many bugs and keep the structure of your data predictable.

--- a/source/typescript.md
+++ b/source/typescript.md
@@ -6,7 +6,7 @@ You can take an advantage of using TypeScript with `apollo-angular`.
 
 <h2 id="generic-types">Generic types</h2>
 
-Every result of GraphQL query is a type of [`ApolloQueryResult`][ApolloQueryResult]. It means that the actual data lives under `data` property. The default type of that property is just a simple object, but you can easily change it.
+Every result of a GraphQL query is a type of [`ApolloQueryResult`][ApolloQueryResult]. It means that the actual data lives under `data` property. The default type of that property is just a simple object, but you can easily change it.
 
 To add an interface to the result, just specify a generic type when using methods like `watchQuery`, `mutate` and more.
 
@@ -43,7 +43,7 @@ class AppComponent {
 
 
 
-Now, the `data` property is a type of `QueryResponse`.
+Now, the `data` property has a type of `QueryResponse`.
 Thanks to this, you can prevent many bugs and keep the structure of your data predictable.
 
 [ApolloQueryResult]: /core/apollo-client-api.html#ApolloQueryResult

--- a/source/typescript.md
+++ b/source/typescript.md
@@ -2,13 +2,15 @@
 title: TypeScript
 ---
 
-You can take an advantage of using TypeScript.
+You can take an advantage of using TypeScript with `apollo-angular`.
 
 <h2 id="generic-types">Generic types</h2>
 
-Every `ApolloQueryResult` has a generic type that you can specify when using methods to manipulate the data.
+Every result of GraphQL query is a type of [`ApolloQueryResult`][ApolloQueryResult]. It means that the actual data lives under `data` property. The default type of that property is just a simple object, but you can easily change it.
 
-For example, let's take a look at `watchQuery` method:
+To add an interface to the result, just specify a generic type when using methods like `watchQuery`, `mutate` and more.
+
+For an example, let's take a look at one of them:
 
 ```ts
 interface User {
@@ -39,5 +41,9 @@ class AppComponent {
 }
 ```
 
-The `data` object is a type of `QueryResponse`. 
+
+
+Now, the `data` property is a type of `QueryResponse`.
 Thanks to this, you can prevent many bugs and keep the structure of your data predictable.
+
+[ApolloQueryResult]: /core/apollo-client-api.html#ApolloQueryResult

--- a/source/webpack.md
+++ b/source/webpack.md
@@ -34,14 +34,14 @@ As you can see, `.graphql` or `.gql` files will be parsed whenever imported:
 
 ```ts
 import { Component } from '@angular/core';
-import { Angular2Apollo } from 'angular2-apollo';
+import { Apollo } from 'apollo-angular';
 
 import currentUserQuery from './currentUser.graphql';
 
 @Component({ ... })
 class ProfileComponent {
   constructor(
-    apollo: Angular2Apollo
+    apollo: Apollo
   ) {
     apollo.query({ query: currentUserQuery })
       .subscribe(result => { ... });


### PR DESCRIPTION
- [x] use `apollo-angular` instead of `angular2-apollo`
- [x] use `Apollo` service instead of `Angular2Apollo`
- [x] introduce `forRoot` (multiple clients)
- [x] mention generic types (or create a whole chapter about TypeScript)
- [x] use `forRoot` instead of `withClient`
- [x] add disclaimer about those changes
- [x] apollostack/apollo-angular#263
- [x] release `v0.10.0`